### PR TITLE
Beta

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM ubuntu:18.04
 # Install required base packages
 RUN \
   apt-get update && \
-  apt-get install -y --no-install-recommends curl cron ca-certificates unzip apt-transport-https gnupg2 software-properties-common
+  apt-get install -y --no-install-recommends curl cron ca-certificates unzip apt-transport-https gnupg2 software-properties-common && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install awscliv2 https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html
 RUN \
@@ -18,12 +19,8 @@ RUN \
   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
   echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
   apt-get update && \
-  apt-get install -y --no-install-recommends docker-ce-cli
-
-# Cleanup
-RUN \
-  apt-get clean && \
-  rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
+  apt-get install -y --no-install-recommends docker-ce-cli && \
+  apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy scripts and allow execution
 COPY ./src/entrypoint.sh ./src/backup.sh /root/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,35 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl cron ca-certificates unzip
-RUN rm -rf /var/lib/apt/lists/*
+# Install required base packages
+RUN \
+  apt-get update && \
+  apt-get install -y --no-install-recommends curl cron ca-certificates unzip apt-transport-https gnupg2 software-properties-common
 
 # Install awscliv2 https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html
-RUN curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-RUN unzip -q awscliv2.zip
-RUN ./aws/install -i /usr/bin -b /usr/bin
-RUN rm -rf ./aws awscliv2.zip
-RUN aws --version
+RUN \
+  curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+  unzip -q awscliv2.zip && \
+  ./aws/install -i /usr/bin -b /usr/bin && \
+  rm -rf ./aws awscliv2.zip && \
+  aws --version
 
-# https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#install-using-the-convenience-script
-RUN curl -fsSL get.docker.com -o get-docker.sh
-RUN sh get-docker.sh
+# Install docker CLI
+RUN \
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+  echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+  apt-get update && \
+  apt-get install -y --no-install-recommends docker-ce-cli
 
-COPY ./src/entrypoint.sh /root/
-COPY ./src/backup.sh /root/
-RUN chmod a+x /root/entrypoint.sh
-RUN chmod a+x /root/backup.sh
+# Cleanup
+RUN \
+  apt-get clean && \
+  rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
+
+# Copy scripts and allow execution
+COPY ./src/entrypoint.sh ./src/backup.sh /root/
+RUN \
+  chmod a+x /root/entrypoint.sh && \
+  chmod a+x /root/backup.sh
 
 WORKDIR /root
 CMD [ "/root/entrypoint.sh" ]


### PR DESCRIPTION
Reduzing image size by more than 50% (411MB vs 857MB) by reducing layers and installing only the Docker CLI.

![size](https://user-images.githubusercontent.com/11077551/112638763-e15d3d00-8e3f-11eb-9705-581fcdbaae19.PNG)

First step was reducing the amount of layes, this reduced it to around 600MB, removing the complete docker installation the image size shrinks to 450 MB.

After adding an apt-clean and removing tmp files the image is finally reduced to 411 MB:

![image](https://user-images.githubusercontent.com/11077551/112641332-93960400-8e42-11eb-8a40-456d3c9cf3b0.png)
